### PR TITLE
restriction of use to allocated points

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.pythonProjects": []
+}

--- a/server.py
+++ b/server.py
@@ -48,7 +48,10 @@ def purchasePlaces():
     places_required = int(request.form['places'])
     if places_required > 12:
         flash("You cannot book more than 12 places per competition.")
-        return render_template('booking.html', club=club, competition=competition)
+        return render_template('booking.html', club=club, competition=competition), 400
+    if places_required > int(club['points']):
+        flash("You cannot book more places than your club's points.")
+        return render_template('booking.html', club=club, competition=competition), 400
     competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-places_required
     flash('Great-booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -5,6 +5,14 @@
     <title>Booking for {{competition['name']}} || GUDLFT</title>
 </head>
 <body>
+    {% with messages = get_flashed_messages()%}
+    {% if messages %}
+        <ul>
+       {% for message in messages %}
+            <li>{{message}}</li>
+        {% endfor %}
+       </ul>
+    {% endif%}
     <h2>{{competition['name']}}</h2>
     Places available: {{competition['numberOfPlaces']}}
     <form action="/purchasePlaces" method="post">
@@ -13,5 +21,6 @@
         <label for="places">How many places?</label><input type="number" name="places" id=""/>
         <button type="submit">Book</button>
     </form>
+    {%endwith%}
 </body>
 </html>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -7,14 +7,6 @@
 <body>
         <h2>Welcome, {{club['email']}} </h2><a href="{{url_for('logout')}}">Logout</a>
 
-    {% with messages = get_flashed_messages()%}
-    {% if messages %}
-        <ul>
-       {% for message in messages %}
-            <li>{{message}}</li>
-        {% endfor %}
-       </ul>
-    {% endif%}
     Points available: {{club['points']}}
     <h3>Competitions:</h3>
     <ul>
@@ -30,7 +22,6 @@
         <hr />
         {% endfor %}
     </ul>
-    {%endwith%}
 
 </body>
 </html>


### PR DESCRIPTION
If a club tries to spend more points than it has, show a flash error and re-render the booking page with HTTP 400.